### PR TITLE
Children props documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ export const UserCreate = (props) => (
 
 The `DependentInput` accepts the following props:
 
+### children
+
+This component expects to receive a single React element child.
+
 ### dependsOn
 
 Either a string indicating the name of the field to check (eg: `hasEmail`) or an array of fields to check (eg: `['firstName', 'lastName']`).

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const getValue = (value, path) => {
 };
 
 const DependentInputComponent = ({ children, show, dependsOn, value, resolve, ...props }) =>
-    show ? <FormField input={children} {...props} /> : null;
+    show ? <FormField input={React.Children.only(children)} {...props} /> : null;
 
 DependentInputComponent.propTypes = {
     children: PropTypes.node.isRequired,


### PR DESCRIPTION
I was getting stuck (and suspecting it was a bug) when using this component with multiple children like this:

```javascript
<DependentInput dependsOn="category" value="programming">
    <TextInput source="language"/>
    <TextInput source="browser"/>
</DependentInput>
```
![screenshot from 2017-05-20 01-52-13](https://cloud.githubusercontent.com/assets/7511692/26273148/37d60d28-3d00-11e7-8d98-5d0dfd7803e6.png)

So, I made this PR improving the error message:
![screenshot from 2017-05-20 01-49-39](https://cloud.githubusercontent.com/assets/7511692/26273214/6170f32c-3d01-11e7-8f84-5172e539c550.png)
